### PR TITLE
Fix the member_for_ugent_nr method (updates #23)

### DIFF
--- a/app/models/member.rb
+++ b/app/models/member.rb
@@ -102,6 +102,7 @@ class Member < ActiveRecord::Base
   def self.member_for_ugent_nr(ugent_nr, club)
     result = Member.joins(:cards)
                    .select('members.*, COUNT(cards.id) as card_count')
+                   .group(:member_id) # See https://github.com/ZeusWPI/FK-enrolment/issues/23
                    .where(:ugent_nr => ugent_nr, :club_id => club.id,
                           :cards => { :enabled => true })
                    .order('card_count DESC, updated_at DESC')


### PR DESCRIPTION
This changes the following queries in https://github.com/ZeusWPI/FK-enrolment/blob/master/app/models/member.rb#L102

```
2.1.1 :155 > Member.joins(:cards).select('members.*, COUNT(cards.id) as card_count').where(:ugent_nr => ugent_nr, :club_id => club.id).order('card_count DESC, updated_at DESC')
  Member Load (1.1ms)  SELECT members.*, COUNT(cards.id) as card_count FROM `members` INNER JOIN `cards` ON `cards`.`member_id` = `members`.`id` WHERE `members`.`ugent_nr` = '00803637' AND `members`.`club_id` = 26 ORDER BY card_count DESC, updated_at DESC
```

To:

```
2.1.1 :154 > Member.joins(:cards).select('members.*, COUNT(cards.id) as card_count').group(:member_id).where(:ugent_nr => ugent_nr, :club_id => club.id).order('card_count DESC, updated_at DESC')
  Member Load (1.2ms)  SELECT members.*, COUNT(cards.id) as card_count FROM `members` INNER JOIN `cards` ON `cards`.`member_id` = `members`.`id` WHERE `members`.`ugent_nr` = '00803637' AND `members`.`club_id` = 26 GROUP BY member_id ORDER BY card_count DESC, updated_at DESC
```
