### PR TITLE
Remove getting old members

### DIFF
--- a/app/controllers/frontend/registration_controller.rb
+++ b/app/controllers/frontend/registration_controller.rb
@@ -31,18 +31,6 @@ class Frontend::RegistrationController < Frontend::FrontendController
   end
 
   def general
-    # Check if there exists a member with this student-ID
-    if !@member.id && cas_authed?
-      student_nr = session[:cas_extra_attributes]["ugentStudentID"]
-      old_record = Member.member_for_ugent_nr(student_nr, @club)
-      if old_record
-        @member = old_record
-        # TODO: add check for re-registering members with a ISIC club that
-        # do not have a photo yet
-        session[:member_id] = old_record.id
-      end
-    end
-
     # Load extra attributes before assigning them
     @member.build_extra_attributes
     @member.attributes = params[:member]

--- a/app/models/member.rb
+++ b/app/models/member.rb
@@ -98,18 +98,6 @@ class Member < ActiveRecord::Base
     end
   end
 
-  # Find a previous member record, given a current student ID
-  def self.member_for_ugent_nr(ugent_nr, club)
-    result = Member.joins(:cards)
-                   .select('members.*, COUNT(cards.id) as card_count')
-                   .group(:member_id) # See https://github.com/ZeusWPI/FK-enrolment/issues/23
-                   .where(:ugent_nr => ugent_nr, :club_id => club.id,
-                          :cards => { :enabled => true })
-                   .order('card_count DESC, updated_at DESC')
-                   .first
-    result.try(:id).to_i != 0 ? result : nil
-  end
-
   def self.active_registrations
     where(:last_registration => self.current_academic_year)
   end

--- a/test/unit/member_test.rb
+++ b/test/unit/member_test.rb
@@ -76,8 +76,4 @@ class MemberTest < ActiveSupport::TestCase
     assert !@member.enabled
   end
 
-  test "should find member with same student number" do
-    result = Member.member_for_ugent_nr(@member.ugent_nr, @member.club)
-    assert_equal @member, result
-  end
 end


### PR DESCRIPTION
Another update for #23 

This methods removes the linking between old members and new members with the same club and ID. 

**Advantage:**
Fixes #23 and any futuru possible problems with this

**Drawback:**
Removes the link between a member and his card during the years. This actually isn't bad as cards don't get revalidated anymore.
